### PR TITLE
Specify Next.js build output directory for deployment

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  distDir: 'dist'
-};
+const nextConfig = {};
 
 export default nextConfig;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  distDir: 'dist'
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "postbuild": "cp -r .next dist",
     "start": "next start",
     "inspector": "mcp-inspector http://localhost:3000/api/mcp"
   },


### PR DESCRIPTION
## Summary
- configure Next.js to emit build artifacts in `dist`

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c5b2c61108832087815aac8b4782ff