### PR TITLE
Bind Next.js server to container port

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ npm run dev
 
 The app runs at <http://localhost:3000>. Try uploading a PDF to see extracted text, or open <http://localhost:3000/mcp> to exercise the MCP tools.
 
+When deploying to container platforms such as Alpic's AWS Lambda environment, the app now binds to the port specified by the `PORT` environment variable (default `8080`) and listens on all interfaces. This prevents startup timeouts during deployment.
+
 ## Production build
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "next dev",
     "build": "next build",
     "postbuild": "cp -r .next dist",
-    "start": "next start",
+    "start": "next start -H 0.0.0.0 -p ${PORT:-8080}",
     "inspector": "mcp-inspector http://localhost:3000/api/mcp"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- ensure Next.js server listens on all interfaces and the PORT env variable (default 8080)
- document container port behavior to avoid startup timeouts in Alpic deployments

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c5e8e01a348320bb4a16bd0a811d1a