### PR TITLE
Expose MCP server at /mcp via middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,13 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  if (request.nextUrl.pathname === '/mcp' && request.method === 'POST') {
+    return NextResponse.rewrite(new URL('/api/mcp', request.url));
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/mcp'],
+};


### PR DESCRIPTION
## Summary
- add Next.js middleware to forward POST /mcp requests to the API handler

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c5f41d79d883209eccdc7a81690cac