### PR TITLE
Expose MCP server at /mcp via middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,20 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  if (request.nextUrl.pathname === '/mcp') {
+    const accept = request.headers.get('accept') || '';
+    if (
+      request.method === 'POST' ||
+      request.method === 'DELETE' ||
+      accept.includes('text/event-stream')
+    ) {
+      return NextResponse.rewrite(new URL('/api/mcp', request.url));
+    }
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/mcp'],
+};

--- a/pages/api/mcp.ts
+++ b/pages/api/mcp.ts
@@ -3,17 +3,6 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { getServer } from "../../src/server";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  if (req.method !== "POST") {
-    res
-      .status(405)
-      .json({
-        jsonrpc: "2.0",
-        error: { code: -32000, message: "Method not allowed." },
-        id: null,
-      });
-    return;
-  }
-
   try {
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: undefined,


### PR DESCRIPTION
## Summary
- allow MCP API route to handle all HTTP methods
- rewrite SSE and other MCP requests from `/mcp` to the API handler

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c5f41d79d883209eccdc7a81690cac