### PR TITLE
Improve scene query handling

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -172,9 +172,11 @@ export const getServer = (): McpServer => {
         .split(/[,/&]|\band\b/i)
         .map((c) => c.trim())
         .filter(Boolean);
-      characters = await Promise.all(list.map((c) => translateToEnglish(c)));
+      const translated = await Promise.all(list.map((c) => translateToEnglish(c)));
+      characters = translated.filter((c): c is string => Boolean(c));
     } else if (Array.isArray(characters)) {
-      characters = await Promise.all(characters.map((c) => translateToEnglish(c)));
+      const translated = await Promise.all(characters.map((c) => translateToEnglish(c)));
+      characters = translated.filter((c): c is string => Boolean(c));
     }
 
     if (typeof sceneNumber === "number") sceneNumber = sceneNumber.toString();
@@ -191,7 +193,8 @@ export const getServer = (): McpServer => {
       setting = s || undefined;
     }
 
-    return { sceneNumber, characters: characters as string[] | undefined, setting, location, time };
+    const chars = Array.isArray(characters) && characters.length ? (characters as string[]) : undefined;
+    return { sceneNumber, characters: chars, setting, location, time };
   }
 
   function normalizeSettingTokens(value: string): string[] {

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,6 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { parseScript } from "../utils/parseScript";
+import type { Scene as ParsedScene, ScenePart } from "../utils/parseScript";
 
 const SceneInfo = z.object({
   setting: z.string(),
@@ -18,6 +19,41 @@ type Scene = z.infer<typeof SceneInfo> & { id: string; raw: string };
 const g = globalThis as any;
 g.__scenariOSSceneStore = g.__scenariOSSceneStore || [];
 const sceneStore: Scene[] = g.__scenariOSSceneStore as Scene[];
+
+function stripDiacritics(str: string): string {
+  return str.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+}
+
+function normalizeText(str: string): string {
+  return stripDiacritics(str).toLowerCase();
+}
+
+function normalizeName(str: string): string {
+  return stripDiacritics(str).toUpperCase();
+}
+
+async function translateToEnglish(text?: string): Promise<string | undefined> {
+  if (!text) return text;
+  const key = process.env.MISTRAL_API_KEY;
+  if (!key) return text;
+  try {
+    const res = await fetch("https://api.mistral.ai/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${key}`,
+      },
+      body: JSON.stringify({
+        model: "mistral-small-latest",
+        messages: [{ role: "user", content: `Translate to English: ${text}` }],
+      }),
+    });
+    const data = await res.json();
+    return data?.choices?.[0]?.message?.content?.trim() || text;
+  } catch {
+    return text;
+  }
+}
 
 export const getServer = (): McpServer => {
   const server = new McpServer({ name: "scenarios-server", version: "0.1.0" }, { capabilities: {} });
@@ -68,6 +104,33 @@ export const getServer = (): McpServer => {
     },
   );
 
+  server.tool(
+    "parse_pdf",
+    "Parse full script text and store scenes",
+    {
+      text: z.string().describe("Full script text from PDF"),
+    },
+    async ({ text }): Promise<CallToolResult> => {
+      const parsed = parseScript(text);
+      sceneStore.length = 0;
+      for (const sc of parsed.scenes as ParsedScene[]) {
+        const rawParts = sc.parts.map((p: ScenePart) =>
+          p.type === "dialogue" ? `${p.character}\n${p.text}` : p.text,
+        );
+        const scene: Scene = {
+          id: sc.sceneNumber.toString(),
+          raw: [sc.heading, ...rawParts].join("\n"),
+          setting: sc.setting,
+          location: sc.location,
+          time: sc.time,
+          characters: sc.characters,
+        };
+        sceneStore.push(scene);
+      }
+      return { content: [{ type: "text", text: `Parsed ${parsed.scenes.length} scenes` }] };
+    },
+  );
+
   const findShape = {
     sceneNumber: z.union([z.string(), z.number()]).optional(),
     characters: z.union([z.string(), z.array(z.string())]).optional(),
@@ -85,40 +148,57 @@ export const getServer = (): McpServer => {
     time?: string;
   };
 
-  const TIME_WORDS = ["night", "day", "dawn", "dusk", "evening", "morning", "afternoon"];
+  const TIME_SYNONYMS: Record<string, string[]> = {
+    night: ["night", "noche", "nuit", "notte"],
+    day: ["day", "dia", "día", "jour"],
+    dawn: ["dawn", "amanecer", "aurore"],
+    dusk: ["dusk", "crepúsculo", "crepusculo", "crépuscule"],
+    evening: ["evening", "soir", "tarde"],
+    morning: ["morning", "mañana", "matin"],
+    afternoon: ["afternoon", "tarde", "aprèm", "apres-midi"],
+  };
 
-  function normalizeParams(raw: z.infer<typeof findSchema>): FindParams {
+  async function normalizeParams(raw: z.infer<typeof findSchema>): Promise<FindParams> {
     let { sceneNumber, characters, setting, location, time } = raw;
 
-    if (typeof sceneNumber === "number") sceneNumber = sceneNumber.toString();
-
+    // translate inputs to English when possible
+    [setting, location, time] = await Promise.all([
+      translateToEnglish(setting),
+      translateToEnglish(location),
+      translateToEnglish(time),
+    ]);
     if (typeof characters === "string") {
-      characters = characters
+      const list = characters
         .split(/[,/&]|\band\b/i)
         .map((c) => c.trim())
         .filter(Boolean);
+      characters = await Promise.all(list.map((c) => translateToEnglish(c)));
+    } else if (Array.isArray(characters)) {
+      characters = await Promise.all(characters.map((c) => translateToEnglish(c)));
     }
+
+    if (typeof sceneNumber === "number") sceneNumber = sceneNumber.toString();
 
     if (setting) {
       let s = setting;
-      for (const word of TIME_WORDS) {
-        const re = new RegExp(`\\b${word}\\b`, "i");
-        if (re.test(s)) {
-          time = time && !time.toLowerCase().includes(word) ? `${time} ${word}` : time || word;
+      for (const [canonical, words] of Object.entries(TIME_SYNONYMS)) {
+        const re = new RegExp(`\\b(${words.map((w) => stripDiacritics(w)).join("|")})\\b`, "i");
+        if (re.test(stripDiacritics(s))) {
+          time = time && !normalizeText(time).includes(canonical) ? `${time} ${canonical}` : time || canonical;
           s = s.replace(re, "").trim();
         }
       }
       setting = s || undefined;
     }
 
-    return { sceneNumber, characters, setting, location, time };
+    return { sceneNumber, characters: characters as string[] | undefined, setting, location, time };
   }
 
   function normalizeSettingTokens(value: string): string[] {
-    const lower = value.toLowerCase();
+    const lower = normalizeText(value);
     const tokens: string[] = [];
-    if (/(^|\/|\b)(int|interior|inside)(\/|\b|$)/.test(lower)) tokens.push("int");
-    if (/(^|\/|\b)(ext|exterior|outside)(\/|\b|$)/.test(lower)) tokens.push("ext");
+    if (/(^|\/|\b)(int|interior|inside|interieur|adentro)(\/|\b|$)/.test(lower)) tokens.push("int");
+    if (/(^|\/|\b)(ext|exterior|outside|exterieur|afuera)(\/|\b|$)/.test(lower)) tokens.push("ext");
     return tokens.length ? tokens : [lower];
   }
 
@@ -129,14 +209,14 @@ export const getServer = (): McpServer => {
   }
 
   function filterScenes({ sceneNumber, characters, setting, location, time }: FindParams) {
-    const chars = characters?.map((c) => c.toUpperCase());
+    const chars = characters?.map((c) => normalizeName(c));
     return sceneStore.filter(
       (s) =>
         (!sceneNumber || s.id === sceneNumber) &&
         (!setting || matchesSetting(s.setting, setting)) &&
-        (!location || s.location.toLowerCase().includes(location.toLowerCase())) &&
-        (!time || s.time.toLowerCase().includes(time.toLowerCase())) &&
-        (!chars || chars.every((c) => s.characters.includes(c))),
+        (!location || normalizeText(s.location).includes(normalizeText(location))) &&
+        (!time || normalizeText(s.time).includes(normalizeText(time))) &&
+        (!chars || chars.every((c) => s.characters.some((sc) => normalizeName(sc) === c))),
     );
   }
 
@@ -155,17 +235,43 @@ export const getServer = (): McpServer => {
     return `${heading}\n${body}`;
   }
 
+  function buildNoResultsMessage({ sceneNumber, characters, setting, location, time }: FindParams) {
+    const parts: string[] = [];
+    if (characters?.length) parts.push(`with ${characters.join(" and ")}`);
+    if (setting) parts.push(`in ${setting}`);
+    if (time) parts.push(`at ${time}`);
+    if (location) parts.push(`in ${location}`);
+    if (sceneNumber) parts.push(`number ${sceneNumber}`);
+    return `There are no scenes ${parts.join(" ")}`.replace(/\s+/g, " ").trim();
+  }
+
   server.tool("find", "Find scenes by number or attributes", findShape, async (params): Promise<CallToolResult> => {
-    const parsed = normalizeParams(findSchema.parse(params));
+    const parsed = await normalizeParams(findSchema.parse(params));
     const results = filterScenes(parsed);
+    if (!results.length)
+      return {
+        content: [
+          { type: "text", text: JSON.stringify([]) },
+          { type: "text", text: buildNoResultsMessage(parsed) },
+        ],
+      };
     return { content: [{ type: "text", text: JSON.stringify(results) }] };
   });
 
   server.tool("print", "Print scenes in formatted markdown", findShape, async (params): Promise<CallToolResult> => {
-    const parsed = normalizeParams(findSchema.parse(params));
+    const parsed = await normalizeParams(findSchema.parse(params));
     const results = filterScenes(parsed);
+    if (!results.length)
+      return { content: [{ type: "text", text: buildNoResultsMessage(parsed) }] };
     const formatted = results.map(formatScene).join("\n\n");
     return { content: [{ type: "text", text: formatted }] };
+  });
+
+  server.tool("count", "Count scenes matching attributes", findShape, async (params): Promise<CallToolResult> => {
+    const parsed = await normalizeParams(findSchema.parse(params));
+    const results = filterScenes(parsed);
+    if (!results.length) return { content: [{ type: "text", text: buildNoResultsMessage(parsed) }] };
+    return { content: [{ type: "text", text: results.length.toString() }] };
   });
 
   return server;


### PR DESCRIPTION
## Summary
- Accept numbers, single names, and comma/and-separated strings in `find` and `print` tool parameters
- Normalize settings and extract time words from setting queries to handle cases like "night exterior"
- Match interior/exterior synonyms case-insensitively for more robust scene filtering

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc src/server.ts --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68c605c4c5b4832085b5154d1c90d033