### PR TITLE
feat: add natural language scene querying

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Prototype web app for analyzing film scripts using the Model Context Protocol.
 ## Features
 
 - Upload a PDF script and extract text via a minimal OCR endpoint.
-- MCP tools `parse_scene`, `search_scenes`, and `query_scenes` for structured and natural language scene search.
+- MCP tools `parse_scene`, `find`, `print`, `count`, and `query_scenes` for structured and natural language scene search.
 - Browser-based MCP tester at `/debug` with streaming results.
 
 ## Development
@@ -38,4 +38,4 @@ MISTRAL_API_KEY=your_key npm run inspector
 Point the inspector's Streamable HTTP URL at `http://localhost:3000/mcp`
 or your deployed application's `/mcp` endpoint.
 
-Use `parse_scene` to add scenes, `search_scenes` for structured filters, or `query_scenes` with natural language like "give me all scenes with Paul and Ana".
+Use `parse_scene` to add scenes, `find` or `print` for structured filters, or `query_scenes` with natural language like "give me all scenes with Paul and Ana".


### PR DESCRIPTION
## Summary
- support natural language scene requests with new `query_scenes` tool
- parse LLM prompts into structured filters via Mistral API
- document new capabilities in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx tsc -p tsconfig.server.json --noEmit` *(fails: Cannot find module 'dotenv' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68c61627c4348320ac4cb5d5bb636605