### PR TITLE
Add calendar, map, and weather integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,34 @@
 # scenariOS
 
-Prototype web app for analyzing film scripts using the Model Context Protocol.
+scenariOS is a Mistral MCP hackathon entry that turns raw film scripts into a schedule-aware production assistant. It exposes a web UI and an MCP server so Le Chat can read scripts, reason about logistics, and update metadata in real time.
 
-## Features
+## Highlights
 
-- Upload a PDF script and extract text via a minimal OCR endpoint.
-- MCP tools `parse_scene`, `find`, `print`, `count`, and `query_scenes` for structured and natural language scene search.
-- Browser-based MCP tester at `/debug` with streaming results.
+- Parse scripts into structured scenes with duration estimates and candidate locations.
+- Persist scenes and characters globally to track actor assignments and metadata.
+- Interactive calendar constrained by global filming dates; tap days to add or remove potential shooting dates and set start times with auto‑calculated end times.
+- Compact map showing the primary location and nearby backups with distance in km plus a "show similar" option.
+- Weather panel forecasting temperature, rain, clouds, visibility, and golden‑hour range for the chosen date and place.
+- Rich scene queries like "print all scheduled scenes" or "how many scenes have more than 3 dates".
+- Browser MCP inspector at `/debug` for trying tools directly in the browser.
+
+## MCP Tools
+
+| Tool | Purpose |
+|------|---------|
+| `parse_pdf` | Parse an entire script and seed scene/character stores. |
+| `parse_scene` | Register or update a single scene with metadata. |
+| `find` | Return scenes matching attributes such as characters, time, or scheduled dates. |
+| `print` | Render matching scenes as formatted markdown. |
+| `count` | Count scenes matching filters. |
+| `query_scenes` | Natural language scene search. |
+| `characters` | List characters and assigned actors. |
+| `assign_actor` | Attach actor name/email to a character. |
+| `update_scene` | Add or remove shooting dates or locations. |
+| `calendar_suggest` | Suggest viable shooting dates for a scene. |
+| `map_search` | Find a location and 3–4 nearby backups. |
+| `map_similar` | Discover similar locations near the current choice. |
+| `weather_forecast` | Fetch weather and light info for a date/location. |
 
 ## Development
 
@@ -17,25 +39,22 @@ npm install
 npm run dev
 ```
 
-The app runs at <http://localhost:3000>. Try uploading a PDF to see extracted text, or open <http://localhost:3000/debug> to exercise the MCP tools.
+Visit <http://localhost:3000> to upload a PDF or interact with the calendar and map panels. The MCP inspector lives at <http://localhost:3000/debug>.
 
-For deployments and MCP clients like Mistral's Le Chat, a standalone Express server is built into `dist/index.js` and serves the MCP endpoint at `/mcp`. The server listens on the port defined by `PORT` (or `MCP_HTTP_PORT`), defaulting to `8080` for platforms such as Alpic's AWS Lambda containers.
-
-## Production build
+For production or Le Chat, build the standalone server which exposes `/mcp`:
 
 ```bash
 npm run build
 ```
 
-## MCP inspector
+The server listens on `PORT` (or `MCP_HTTP_PORT`), defaulting to `8080`.
 
-Set `MISTRAL_API_KEY` in your environment (server runtime) and test the MCP endpoint with the inspector:
+## MCP Inspector
+
+Set `MISTRAL_API_KEY` and start the inspector:
 
 ```bash
 MISTRAL_API_KEY=your_key npm run inspector
 ```
 
-Point the inspector's Streamable HTTP URL at `http://localhost:3000/mcp`
-or your deployed application's `/mcp` endpoint.
-
-Use `parse_scene` to add scenes, `find` or `print` for structured filters, or `query_scenes` with natural language like "give me all scenes with Paul and Ana".
+Point the inspector's streamable URL at `http://localhost:3000/mcp` (or your deployed endpoint) and call tools such as `calendar_suggest`, `map_search`, `weather_forecast`, or any of the scene query helpers to drive scheduling decisions from Le Chat.

--- a/components/Calendar.tsx
+++ b/components/Calendar.tsx
@@ -1,0 +1,89 @@
+import React, { useState } from "react";
+
+interface Props {
+  available: string[];
+  onSelect?: (date: string) => void;
+}
+
+function format(d: Date) {
+  return d.toISOString().split("T")[0];
+}
+
+export default function Calendar({ available, onSelect }: Props) {
+  const [current, setCurrent] = useState(new Date());
+  const year = current.getFullYear();
+  const month = current.getMonth();
+  const first = new Date(year, month, 1);
+  const start = first.getDay();
+  const days = new Date(year, month + 1, 0).getDate();
+
+  const weeks: (number | null)[][] = [];
+  let week: (number | null)[] = Array(start).fill(null);
+  for (let d = 1; d <= days; d++) {
+    week.push(d);
+    if (week.length === 7) {
+      weeks.push(week);
+      week = [];
+    }
+  }
+  if (week.length) weeks.push([...week, ...Array(7 - week.length).fill(null)]);
+
+  return (
+    <div className="w-full">
+      <div className="mb-2 flex items-center justify-between text-sm font-medium">
+        <button
+          type="button"
+          onClick={() => setCurrent(new Date(year, month - 1, 1))}
+          className="rounded px-2 py-1 hover:bg-gray-200"
+        >
+          ←
+        </button>
+        <span>
+          {current.toLocaleString("default", { month: "long" })} {year}
+        </span>
+        <button
+          type="button"
+          onClick={() => setCurrent(new Date(year, month + 1, 1))}
+          className="rounded px-2 py-1 hover:bg-gray-200"
+        >
+          →
+        </button>
+      </div>
+      <table className="w-full table-fixed text-center text-sm">
+        <thead>
+          <tr className="text-gray-500">
+            {["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"].map((d) => (
+              <th key={d}>{d}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {weeks.map((w, i) => (
+            <tr key={i}>
+              {w.map((day, j) => {
+                if (!day) return <td key={j}></td>;
+                const date = format(new Date(year, month, day));
+                const availableDay = available.includes(date);
+                return (
+                  <td key={j} className="p-1">
+                    <button
+                      type="button"
+                      onClick={() => availableDay && onSelect?.(date)}
+                      className={`h-8 w-8 rounded-full border text-xs ${
+                        availableDay
+                          ? "bg-blue-200 hover:bg-blue-300"
+                          : "text-gray-400"
+                      }`}
+                    >
+                      {day}
+                    </button>
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/components/Calendar.tsx
+++ b/components/Calendar.tsx
@@ -2,14 +2,15 @@ import React, { useState } from "react";
 
 interface Props {
   available: string[];
-  onSelect?: (date: string) => void;
+  selected?: string[];
+  onToggle?: (date: string) => void;
 }
 
 function format(d: Date) {
   return d.toISOString().split("T")[0];
 }
 
-export default function Calendar({ available, onSelect }: Props) {
+export default function Calendar({ available, selected = [], onToggle }: Props) {
   const [current, setCurrent] = useState(new Date());
   const year = current.getFullYear();
   const month = current.getMonth();
@@ -64,14 +65,17 @@ export default function Calendar({ available, onSelect }: Props) {
                 if (!day) return <td key={j}></td>;
                 const date = format(new Date(year, month, day));
                 const availableDay = available.includes(date);
+                const picked = selected.includes(date);
                 return (
                   <td key={j} className="p-1">
                     <button
                       type="button"
-                      onClick={() => availableDay && onSelect?.(date)}
+                      onClick={() => availableDay && onToggle?.(date)}
                       className={`h-8 w-8 rounded-full border text-xs ${
                         availableDay
-                          ? "bg-blue-200 hover:bg-blue-300"
+                          ? picked
+                            ? "bg-blue-500 text-white hover:bg-blue-600"
+                            : "bg-blue-200 hover:bg-blue-300"
                           : "text-gray-400"
                       }`}
                     >

--- a/components/LocationMap.tsx
+++ b/components/LocationMap.tsx
@@ -4,6 +4,7 @@ interface Location {
   name: string;
   lat: number;
   lon: number;
+  distanceKm?: number;
 }
 
 interface Props {
@@ -13,32 +14,41 @@ interface Props {
 }
 
 export default function LocationMap({ location, backups, onSelect }: Props) {
-  const bbox = location
-    ? `${location.lon - 0.01},${location.lat - 0.01},${location.lon + 0.01},${
-        location.lat + 0.01
-      }`
-    : undefined;
+  const markers: string[] = [];
+  if (location) markers.push(`${location.lat},${location.lon},red`);
+  backups?.forEach((b) => markers.push(`${b.lat},${b.lon},blue`));
+  const markerParams = markers.map((m) => `markers=${m}`).join("&");
+  const src =
+    location && markerParams
+      ? `https://staticmap.openstreetmap.de/staticmap.php?center=${location.lat},${location.lon}&zoom=14&size=600x300&${markerParams}`
+      : undefined;
   return (
     <div className="space-y-2">
-      {location ? (
-        <iframe
-          title="map"
-          className="h-48 w-full rounded"
-          src={`https://www.openstreetmap.org/export/embed.html?bbox=${bbox}&layer=mapnik&marker=${location.lat},${location.lon}`}
-        />
+      {location && src ? (
+        <img src={src} alt="map" className="h-48 w-full rounded object-cover" />
       ) : (
         <div className="text-gray-500">No location selected</div>
       )}
       {backups && backups.length > 0 && (
-        <ul className="space-y-1 text-xs text-blue-600 underline">
-          {backups.map((b) => (
-            <li key={b.name}>
-              <button type="button" onClick={() => onSelect?.(b)}>
-                {b.name}
-              </button>
-            </li>
-          ))}
-        </ul>
+        <div>
+          <h4 className="text-[10px] font-semibold uppercase tracking-wider text-gray-500">Backups</h4>
+          <ul className="mt-1 space-y-1 text-xs">
+            {backups.map((b) => (
+              <li key={b.name} className="flex items-center justify-between">
+                <button
+                  type="button"
+                  onClick={() => onSelect?.(b)}
+                  className="flex-1 text-left text-blue-600 underline"
+                >
+                  {b.name}
+                </button>
+                {typeof b.distanceKm === "number" && (
+                  <span className="ml-2 text-gray-500">{b.distanceKm.toFixed(1)} km</span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
       )}
     </div>
   );

--- a/components/LocationMap.tsx
+++ b/components/LocationMap.tsx
@@ -20,18 +20,20 @@ export default function LocationMap({ location, backups, onSelect }: Props) {
   const markerParams = markers.map((m) => `markers=${m}`).join("&");
   const src =
     location && markerParams
-      ? `https://staticmap.openstreetmap.de/staticmap.php?center=${location.lat},${location.lon}&zoom=14&size=600x300&${markerParams}`
+      ? `https://staticmap.openstreetmap.de/staticmap.php?center=${location.lat},${location.lon}&zoom=14&size=400x200&${markerParams}`
       : undefined;
   return (
     <div className="space-y-2">
       {location && src ? (
-        <img src={src} alt="map" className="h-48 w-full rounded object-cover" />
+        <img src={src} alt="map" className="h-40 w-full rounded object-cover" />
       ) : (
         <div className="text-gray-500">No location selected</div>
       )}
       {backups && backups.length > 0 && (
         <div>
-          <h4 className="text-[10px] font-semibold uppercase tracking-wider text-gray-500">Backups</h4>
+          <h4 className="text-[10px] font-semibold uppercase tracking-wider text-gray-500">
+            Backups (distance from chosen)
+          </h4>
           <ul className="mt-1 space-y-1 text-xs">
             {backups.map((b) => (
               <li key={b.name} className="flex items-center justify-between">
@@ -43,7 +45,9 @@ export default function LocationMap({ location, backups, onSelect }: Props) {
                   {b.name}
                 </button>
                 {typeof b.distanceKm === "number" && (
-                  <span className="ml-2 text-gray-500">{b.distanceKm.toFixed(1)} km</span>
+                  <span className="ml-2 text-gray-500">
+                    {b.distanceKm.toFixed(1)} km
+                  </span>
                 )}
               </li>
             ))}

--- a/components/LocationMap.tsx
+++ b/components/LocationMap.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+
+interface Location {
+  name: string;
+  lat: number;
+  lon: number;
+}
+
+interface Props {
+  location?: Location;
+  backups?: Location[];
+  onSelect?: (loc: Location) => void;
+}
+
+export default function LocationMap({ location, backups, onSelect }: Props) {
+  const bbox = location
+    ? `${location.lon - 0.01},${location.lat - 0.01},${location.lon + 0.01},${
+        location.lat + 0.01
+      }`
+    : undefined;
+  return (
+    <div className="space-y-2">
+      {location ? (
+        <iframe
+          title="map"
+          className="h-48 w-full rounded"
+          src={`https://www.openstreetmap.org/export/embed.html?bbox=${bbox}&layer=mapnik&marker=${location.lat},${location.lon}`}
+        />
+      ) : (
+        <div className="text-gray-500">No location selected</div>
+      )}
+      {backups && backups.length > 0 && (
+        <ul className="space-y-1 text-xs text-blue-600 underline">
+          {backups.map((b) => (
+            <li key={b.name}>
+              <button type="button" onClick={() => onSelect?.(b)}>
+                {b.name}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/components/WeatherPanel.tsx
+++ b/components/WeatherPanel.tsx
@@ -10,7 +10,12 @@ export default function WeatherPanel({ lat, lon, date }: Props) {
   const [info, setInfo] = useState<{
     max?: number;
     min?: number;
-    code?: number;
+    rain?: number;
+    clouds?: number;
+    visibility?: number;
+    chance?: number;
+    sunrise?: string;
+    sunset?: string;
   } | null>(null);
 
   useEffect(() => {
@@ -49,12 +54,28 @@ export default function WeatherPanel({ lat, lon, date }: Props) {
   if (!lat || !lon || !date)
     return <div className="text-gray-500">Select date & location</div>;
   if (!info) return <div className="text-gray-500">No forecast</div>;
+  const goldenStart = info.sunrise ? new Date(info.sunrise) : null;
+  const goldenEnd = info.sunset ? new Date(info.sunset) : null;
+  if (goldenStart) goldenStart.setMinutes(goldenStart.getMinutes() + 60);
+  if (goldenEnd) goldenEnd.setMinutes(goldenEnd.getMinutes() - 60);
   return (
-    <div className="text-sm">
+    <div className="space-y-1 text-sm">
       <div>
         High {info.max}°C / Low {info.min}°C
       </div>
-      <div>Code: {info.code}</div>
+      {info.clouds !== undefined && <div>Clouds: {info.clouds.toFixed(0)}%</div>}
+      {info.visibility !== undefined && (
+        <div>Visibility: {(info.visibility / 1000).toFixed(1)} km</div>
+      )}
+      {info.chance !== undefined && <div>Chance of rain: {info.chance}%</div>}
+      {info.rain !== undefined && <div>Rain: {info.rain} mm</div>}
+      {goldenStart && goldenEnd && (
+        <div>
+          Golden hour: {goldenStart.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })} -
+          {" "}
+          {goldenEnd.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+        </div>
+      )}
     </div>
   );
 }

--- a/components/WeatherPanel.tsx
+++ b/components/WeatherPanel.tsx
@@ -1,0 +1,60 @@
+import React, { useEffect, useState } from "react";
+
+interface Props {
+  lat?: number;
+  lon?: number;
+  date?: string; // YYYY-MM-DD
+}
+
+export default function WeatherPanel({ lat, lon, date }: Props) {
+  const [info, setInfo] = useState<{
+    max?: number;
+    min?: number;
+    code?: number;
+  } | null>(null);
+
+  useEffect(() => {
+    if (!lat || !lon || !date) return;
+    const controller = new AbortController();
+    fetch("/mcp", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: Date.now(),
+        method: "tools/call",
+        params: {
+          name: "weather_forecast",
+          arguments: { lat, lon, date },
+        },
+      }),
+      signal: controller.signal,
+    })
+      .then((r) => r.json())
+      .then((data) => {
+        try {
+          const text = data?.result?.content?.[0]?.text;
+          if (text) setInfo(JSON.parse(text));
+        } catch {
+          setInfo(null);
+        }
+      })
+      .catch(() => setInfo(null));
+    return () => controller.abort();
+  }, [lat, lon, date]);
+
+  if (!lat || !lon || !date)
+    return <div className="text-gray-500">Select date & location</div>;
+  if (!info) return <div className="text-gray-500">No forecast</div>;
+  return (
+    <div className="text-sm">
+      <div>
+        High {info.max}°C / Low {info.min}°C
+      </div>
+      <div>Code: {info.code}</div>
+    </div>
+  );
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -178,6 +178,17 @@ export default function Home() {
     );
   }
 
+  function updateScene(index: number, partial: Partial<Scene>) {
+    setScenes((prev) => {
+      const next = [...prev];
+      next[index] = { ...next[index], ...partial };
+      if (typeof window !== "undefined") {
+        localStorage.setItem("scenes", JSON.stringify(next));
+      }
+      return next;
+    });
+  }
+
   return (
     <main className="flex h-full flex-col overflow-hidden bg-gradient-to-br from-gray-50 to-gray-200">
       <div className="mx-auto flex w-full max-w-5xl flex-1 min-h-0 flex-col overflow-hidden p-6">
@@ -216,6 +227,7 @@ export default function Home() {
               scenes={scenes}
               characters={characters}
               onAssignActor={assignActor}
+              onUpdateScene={updateScene}
             />
           </div>
         )}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Link from "next/link";
 import FileUploader from "../components/FileUploader";
 import ScriptDisplay from "../components/ScriptDisplay";
@@ -12,6 +12,15 @@ export default function Home() {
   const [title, setTitle] = useState("");
   const [author, setAuthor] = useState("");
   const [debugVisible, setDebugVisible] = useState(false);
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      localStorage.setItem("filmingStart", startDate);
+      localStorage.setItem("filmingEnd", endDate);
+    }
+  }, [startDate, endDate]);
 
   async function fetchAllScenes(): Promise<any[]> {
     const res = await fetch("/mcp", {
@@ -219,6 +228,26 @@ export default function Home() {
           <div className="mb-4 text-left">
             <h2 className="text-2xl font-semibold text-gray-900">{title}</h2>
             <p className="mt-1 text-base text-gray-700">by {author}</p>
+            <div className="mt-2 flex gap-4 text-sm text-gray-700">
+              <label className="flex items-center gap-1">
+                <span>Start:</span>
+                <input
+                  type="date"
+                  value={startDate}
+                  onChange={(e) => setStartDate(e.target.value)}
+                  className="rounded border px-1"
+                />
+              </label>
+              <label className="flex items-center gap-1">
+                <span>End:</span>
+                <input
+                  type="date"
+                  value={endDate}
+                  onChange={(e) => setEndDate(e.target.value)}
+                  className="rounded border px-1"
+                />
+              </label>
+            </div>
           </div>
         )}
         {scenes.length > 0 && (
@@ -228,6 +257,8 @@ export default function Home() {
               characters={characters}
               onAssignActor={assignActor}
               onUpdateScene={updateScene}
+              filmingStart={startDate}
+              filmingEnd={endDate}
             />
           </div>
         )}


### PR DESCRIPTION
## Summary
- add navigable calendar component to pick suggested shooting dates
- embed OpenStreetMap with backup locations and weather forecast
- expose new MCP tools for calendar suggestions, map search, and weather forecast

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6312f17008320b2cfb9ffd17d9b01