### PR TITLE
Refine layout and scene navigation visuals

### DIFF
--- a/components/ScriptDisplay.tsx
+++ b/components/ScriptDisplay.tsx
@@ -136,7 +136,7 @@ export default function ScriptDisplay({
 
   return (
     <div
-      className="flex h-full min-h-0 flex-col overflow-hidden"
+      className="flex h-full min-h-0 flex-col overflow-y-hidden"
       style={{ fontFamily: "Courier, monospace" }}
     >
       <div className="mb-4 flex justify-center">
@@ -168,13 +168,14 @@ export default function ScriptDisplay({
           )}
         </div>
       </div>
-      <div className="flex flex-1 gap-6 overflow-hidden">
+      <div className="flex flex-1 gap-6 overflow-visible">
         <div className="w-56 flex-shrink-0 overflow-y-auto rounded-xl border border-gray-200 bg-white shadow-lg" ref={listRef}>
           {filteredScenes.map((scene, idx) => {
             const originalIdx = scenes.indexOf(scene);
             const displayNumber = scene.sceneNumber || originalIdx + 1;
             const type = scene.setting;
             const rest = scene.location;
+            const weight = scene.sceneDuration ? ` (${scene.sceneDuration}s)` : "";
             return (
               <button
                 key={idx}
@@ -190,7 +191,6 @@ export default function ScriptDisplay({
                 }`}
               >
                 <div className="flex items-center justify-between">
-                  <span className="text-xs text-gray-500">{displayNumber}</span>
                   <div className="flex gap-1">
                     {type && (
                       <span className="rounded bg-gray-200 px-1 text-[10px] font-semibold text-gray-700">{type}</span>
@@ -201,13 +201,17 @@ export default function ScriptDisplay({
                       </span>
                     )}
                   </div>
+                  <span className="text-xs text-gray-500">
+                    {displayNumber}
+                    {weight}
+                  </span>
                 </div>
                 <div className="mt-1 text-xs text-gray-700">{rest}</div>
               </button>
             );
           })}
         </div>
-        <div ref={viewerRef} className="flex-1 overflow-y-auto px-6 pb-6 pt-0 space-y-8">
+        <div ref={viewerRef} className="flex-1 overflow-y-auto px-4 pb-6 pt-0 space-y-8">
           {filteredScenes.map((scene, idx) => {
             const originalIdx = scenes.indexOf(scene);
             const displayNumber = scene.sceneNumber || originalIdx + 1;
@@ -219,9 +223,9 @@ export default function ScriptDisplay({
                 }}
                 data-index={idx}
               >
-                <div className="sticky top-0 z-10 -mx-6 rounded-b-xl bg-white/70 px-6 py-2 backdrop-blur-sm shadow">
+                <div className="sticky top-0 z-10 -mx-4 bg-white px-4 py-2">
                   <div className="flex flex-wrap items-center gap-2 text-sm">
-                    <span className="font-semibold text-gray-700">{`${displayNumber}. ${scene.location}`}</span>
+                    <span className="font-semibold text-gray-700">{displayNumber}</span>
                     {scene.setting && (
                       <span className="rounded bg-gray-200 px-1 text-xs font-semibold text-gray-700">
                         {scene.setting}
@@ -230,7 +234,8 @@ export default function ScriptDisplay({
                     {scene.time && (
                       <span className="rounded bg-gray-200 px-1 text-xs font-semibold text-gray-700">{scene.time}</span>
                     )}
-                    <div className="flex flex-wrap gap-1 min-h-[1.25rem]">
+                    <span className="text-gray-700">{scene.location}</span>
+                    <div className="ml-auto flex flex-wrap gap-1 min-h-[1.25rem]">
                       {scene.characters.map((c) => (
                         <span key={c} className={`rounded px-1 text-xs font-bold ${colorMap[c]} text-gray-800`}>
                           {c}
@@ -252,7 +257,7 @@ export default function ScriptDisplay({
         </div>
         <div
           ref={infoRef}
-          className="w-80 flex-shrink-0 overflow-y-auto rounded-3xl border border-white/20 bg-gradient-to-br from-white/70 to-white/40 p-6 shadow-2xl backdrop-blur-xl hidden lg:block"
+          className="hidden w-80 flex-shrink-0 overflow-y-auto rounded-3xl border border-white/20 bg-gradient-to-br from-white/70 to-white/40 p-6 shadow-2xl backdrop-blur-xl lg:block"
         >
           {filteredScenes[activeScene] ? (
             <SceneInfoPanel
@@ -269,7 +274,7 @@ export default function ScriptDisplay({
           )}
         </div>
       </div>
-      <div className="mt-4 flex items-start gap-6 overflow-x-auto pb-3 scroll-px-6 min-h-[5rem] [&>*:first-child]:pl-6 [&>*:last-child]:pr-6">
+      <div className="mt-2 flex items-start gap-6 overflow-x-auto pb-2 scroll-px-4 min-h-[5rem] [&>*:first-child]:pl-4 [&>*:last-child]:pr-4">
         {filterChar && (
           <button
             onClick={() => {
@@ -306,7 +311,7 @@ export default function ScriptDisplay({
                         requestAnimationFrame(() => viewerRef.current?.scrollTo({ top: 0, behavior: "smooth" }));
                       }
                     }}
-                className={`flex-shrink-0 w-40 rounded-lg border bg-white px-3 py-1.5 text-left shadow-sm hover:bg-gray-50 ${
+                    className={`flex-shrink-0 w-40 h-32 rounded-lg border bg-white px-3 py-2 text-left shadow-sm hover:bg-gray-50 ${
                       filterChar === char.name ? "bg-gray-100 font-bold" : ""
                     }`}
                   >
@@ -356,7 +361,7 @@ export default function ScriptDisplay({
                         requestAnimationFrame(() => viewerRef.current?.scrollTo({ top: 0, behavior: "smooth" }));
                       }
                     }}
-                className={`flex-shrink-0 w-40 rounded-lg border bg-white px-3 py-1.5 text-left shadow-sm hover:bg-gray-50 ${
+                    className={`flex-shrink-0 w-40 h-32 rounded-lg border bg-white px-3 py-2 text-left shadow-sm hover:bg-gray-50 ${
                       filterChar === char.name ? "bg-gray-100 font-bold" : ""
                     }`}
                   >

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -199,11 +199,11 @@ export default function Home() {
   }
 
   return (
-    <main className="flex h-full flex-col overflow-hidden bg-gradient-to-br from-gray-50 to-gray-200">
-      <div className="mx-auto flex w-full max-w-5xl flex-1 min-h-0 flex-col overflow-hidden p-6">
-        <div className="mb-4 flex items-center justify-between">
-          <h1 className="text-base font-light text-gray-600">scenariOS</h1>
-          <div className="flex gap-2">
+    <main className="flex min-h-dvh flex-col overflow-hidden bg-gradient-to-br from-gray-50 to-gray-200">
+      <div className="flex w-full flex-1 min-h-0 flex-col overflow-hidden px-4 py-6">
+        <div className="mb-2 flex items-center justify-between">
+          <h1 className="text-sm font-light text-gray-600">scenariOS</h1>
+          <div>
             <button
               type="button"
               onClick={() => setDebugVisible(true)}
@@ -211,40 +211,34 @@ export default function Home() {
             >
               Debug
             </button>
-            <Link
-              href="/debug"
-              className="rounded bg-gray-200 px-3 py-1 text-sm text-gray-700 hover:bg-gray-300"
-            >
-              Debug Page
-            </Link>
           </div>
         </div>
         {!scenes.length ? (
           <>
-            <h2 className="mt-8 text-2xl font-light tracking-tight text-gray-900">Upload Film Script</h2>
+            <h2 className="mt-8 text-xl font-light tracking-tight text-gray-900">Upload Film Script</h2>
             <FileUploader onFile={processFile} loading={loading} />
           </>
         ) : (
           <div className="mb-4 text-left">
-            <h2 className="text-2xl font-semibold text-gray-900">{title}</h2>
-            <p className="mt-1 text-base text-gray-700">by {author}</p>
-            <div className="mt-2 flex gap-4 text-sm text-gray-700">
-              <label className="flex items-center gap-1">
+            <h2 className="text-xl font-semibold text-gray-900">{title}</h2>
+            <p className="mt-1 text-sm text-gray-700">by {author}</p>
+            <div className="mt-2 flex gap-3 text-sm text-gray-700">
+              <label className="flex items-center gap-2">
                 <span>Start:</span>
                 <input
                   type="date"
                   value={startDate}
                   onChange={(e) => setStartDate(e.target.value)}
-                  className="rounded border px-1"
+                  className="rounded-md border border-gray-300 bg-white px-2 py-1 shadow-sm focus:outline-none focus:ring-2 focus:ring-gray-400"
                 />
               </label>
-              <label className="flex items-center gap-1">
+              <label className="flex items-center gap-2">
                 <span>End:</span>
                 <input
                   type="date"
                   value={endDate}
                   onChange={(e) => setEndDate(e.target.value)}
-                  className="rounded border px-1"
+                  className="rounded-md border border-gray-300 bg-white px-2 py-1 shadow-sm focus:outline-none focus:ring-2 focus:ring-gray-400"
                 />
               </label>
             </div>
@@ -264,8 +258,8 @@ export default function Home() {
         )}
       </div>
       {debugVisible && (
-        <div className="fixed inset-0 z-50 overflow-auto bg-black/50 p-6">
-          <div className="mx-auto max-w-5xl">
+        <div className="fixed inset-x-0 top-0 z-50 h-dvh overflow-auto bg-black/50 p-4 sm:p-6">
+          <div className="mx-auto">
             <div className="mb-4 text-right">
               <button
                 type="button"


### PR DESCRIPTION
## Summary
- use dynamic viewport height and slimmer padding for a fuller layout
- streamline header, typography, and date selectors
- redesign scene navigation and indicator for clearer, unclipped presentation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c66418fe8883208f35f3c8fac261d6