### PR TITLE
Refine docs and streamline call sheet tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # scenariOS
 
-scenariOS is a Mistral MCP hackathon entry that turns raw film scripts into a schedule-aware production assistant. It exposes a web UI and an MCP server so Le Chat can read scripts, reason about logistics, and update metadata in real time.
+scenariOS transforms raw film scripts into a schedule-aware production assistant. It combines a responsive web interface with a Model Context Protocol (MCP) server so Le Chat can reason about scenes, logistics, and scheduling in real time.
 
 ## Highlights
 
-- Parse scripts into structured scenes with duration estimates and candidate locations.
-- Persist scenes and characters globally to track actor assignments and metadata.
-- Interactive calendar constrained by global filming dates; tap days to add or remove potential shooting dates and set start times with auto‑calculated end times.
-- Compact map showing the primary location and nearby backups with distance in km plus a "show similar" option.
-- Weather panel forecasting temperature, rain, clouds, visibility, and golden‑hour range for the chosen date and place.
-- Rich scene queries like "print all scheduled scenes" or "how many scenes have more than 3 dates".
-- Browser MCP inspector at `/debug` for trying tools directly in the browser.
+- Parse scripts into structured scenes with duration estimates and candidate shooting locations.
+- Persist scenes and characters to track actor assignments and scene metadata across sessions.
+- Interactive calendar constrained by global filming dates; tap days to add or remove potential shooting dates with auto-calculated end times.
+- Compact map showing the primary location and nearby backups with distances in kilometers plus a "show similar" option.
+- Weather panel forecasting temperature, rain, clouds, visibility, and golden-hour range for the chosen date and place.
+- Rich scene queries such as "print all scheduled scenes" or "how many scenes have more than 3 dates".
+- Built-in MCP inspector at `/debug` for exercising tools directly in the browser.
 
 ## MCP Tools
 
@@ -18,17 +18,14 @@ scenariOS is a Mistral MCP hackathon entry that turns raw film scripts into a sc
 |------|---------|
 | `parse_pdf` | Parse an entire script and seed scene/character stores. |
 | `parse_scene` | Register or update a single scene with metadata. |
-| `find` | Return scenes matching attributes such as characters, time, or scheduled dates. |
+| `find` | Return scenes matching attributes such as characters, time or scheduled dates. |
 | `print` | Render matching scenes as formatted markdown. |
-| `count` | Count scenes matching filters. |
+| `print_pdf` | Render matching scenes as a downloadable PDF. |
 | `query_scenes` | Natural language scene search. |
+| `count` | Count scenes matching filters. |
 | `characters` | List characters and assigned actors. |
 | `assign_actor` | Attach actor name/email to a character. |
-| `send_actor_scenes_doc` | Create and email an actor's scenes in Google Docs. |
-| `create_call_sheet_doc` | Generate a Google Docs call sheet for scenes. |
-| `create_call_sheet_sheet` | Generate a Google Sheets call sheet for scenes. |
-| `create_call_sheet_pdf` | Generate a PDF call sheet for scenes. |
-| `print_pdf` | Render matching scenes as a downloadable PDF. |
+| `create_call_sheet_pdf` | Generate and share a PDF call sheet for scenes. |
 | `update_scene` | Add or remove shooting dates or locations. |
 | `calendar_suggest` | Suggest viable shooting dates for a scene. |
 | `map_search` | Find a location and 3–4 nearby backups. |
@@ -54,6 +51,11 @@ npm run build
 
 The server listens on `PORT` (or `MCP_HTTP_PORT`), defaulting to `8080`.
 
+To generate call sheet PDFs, provide Google service account credentials:
+
+- `GOOGLE_SERVICE_ACCOUNT_EMAIL`
+- `GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY`
+
 ## MCP Inspector
 
 Set `MISTRAL_API_KEY` and start the inspector:
@@ -62,4 +64,4 @@ Set `MISTRAL_API_KEY` and start the inspector:
 MISTRAL_API_KEY=your_key npm run inspector
 ```
 
-Point the inspector's streamable URL at `http://localhost:3000/mcp` (or your deployed endpoint) and call tools such as `calendar_suggest`, `map_search`, `weather_forecast`, or any of the scene query helpers to drive scheduling decisions from Le Chat.
+Point the inspector's streamable URL at `http://localhost:3000/mcp` (or your deployed endpoint) and call tools such as `calendar_suggest`, `map_search`, `weather_forecast` or any of the scene query helpers to drive scheduling decisions from Le Chat.

--- a/components/McpDebug.tsx
+++ b/components/McpDebug.tsx
@@ -25,9 +25,7 @@ export default function McpDebug() {
   const [assignActorName, setAssignActorName] = useState('');
   const [assignActorEmail, setAssignActorEmail] = useState('');
   const [assignResult, setAssignResult] = useState('');
-  const [sendCharacter, setSendCharacter] = useState('');
-  const [sendResult, setSendResult] = useState('');
-  const [callSceneIds, setCallSceneIds] = useState('');
+    const [callSceneIds, setCallSceneIds] = useState('');
   const [callSheetResult, setCallSheetResult] = useState('');
   const [metaResult, setMetaResult] = useState('');
 
@@ -213,48 +211,12 @@ export default function McpDebug() {
     );
   }
 
-  async function runSendScenes() {
-    await callMcp(
-      {
-        jsonrpc: '2.0',
-        id: Date.now(),
-        method: 'tools/call',
-        params: { name: 'send_actor_scenes_doc', arguments: { character: sendCharacter } },
-      },
-      setSendResult,
-    );
-  }
-
-  function parseSceneIds(): string[] {
-    return callSceneIds
-      .split(',')
-      .map((s) => s.trim())
-      .filter(Boolean);
-  }
-
-  async function runCallSheetDoc() {
-    await callMcp(
-      {
-        jsonrpc: '2.0',
-        id: Date.now(),
-        method: 'tools/call',
-        params: { name: 'create_call_sheet_doc', arguments: { sceneIds: parseSceneIds() } },
-      },
-      setCallSheetResult,
-    );
-  }
-
-  async function runCallSheetSheet() {
-    await callMcp(
-      {
-        jsonrpc: '2.0',
-        id: Date.now(),
-        method: 'tools/call',
-        params: { name: 'create_call_sheet_sheet', arguments: { sceneIds: parseSceneIds() } },
-      },
-      setCallSheetResult,
-    );
-  }
+    function parseSceneIds(): string[] {
+      return callSceneIds
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+    }
 
   async function runCallSheetPdf() {
     await callMcp(
@@ -477,61 +439,27 @@ export default function McpDebug() {
           </pre>
         </section>
 
-        <section className="flex flex-col rounded border bg-white p-4 shadow">
-          <h2 className="mb-2 font-medium">Send Actor Scenes</h2>
-          <input
-            className="mb-2 rounded border p-2"
-            placeholder="Character"
-            value={sendCharacter}
-            onChange={(e) => setSendCharacter(e.target.value)}
-          />
-          <button
-            type="button"
-            className="rounded bg-red-600 px-3 py-1 text-white hover:bg-red-700"
-            onClick={runSendScenes}
-          >
-            Send
-          </button>
-          <pre className="mt-2 h-48 overflow-auto whitespace-pre-wrap break-words rounded bg-gray-100 p-2 text-sm">
-            {sendResult}
-          </pre>
-        </section>
-
-        <section className="flex flex-col rounded border bg-white p-4 shadow">
-          <h2 className="mb-2 font-medium">Create Call Sheet</h2>
-          <input
-            className="mb-2 rounded border p-2"
-            placeholder="Comma-separated scene IDs"
-            value={callSceneIds}
-            onChange={(e) => setCallSceneIds(e.target.value)}
-          />
-          <div className="flex gap-2">
-            <button
-              type="button"
-              className="rounded bg-green-600 px-3 py-1 text-white hover:bg-green-700"
-              onClick={runCallSheetDoc}
-            >
-              Google Doc
-            </button>
-            <button
-              type="button"
-              className="rounded bg-green-600 px-3 py-1 text-white hover:bg-green-700"
-              onClick={runCallSheetSheet}
-            >
-              Google Sheet
-            </button>
-            <button
-              type="button"
-              className="rounded bg-green-600 px-3 py-1 text-white hover:bg-green-700"
-              onClick={runCallSheetPdf}
-            >
-              PDF
-            </button>
-          </div>
-          <pre className="mt-2 h-48 overflow-auto whitespace-pre-wrap break-words rounded bg-gray-100 p-2 text-sm">
-            {callSheetResult}
-          </pre>
-        </section>
+          <section className="flex flex-col rounded border bg-white p-4 shadow">
+            <h2 className="mb-2 font-medium">Create Call Sheet</h2>
+            <input
+              className="mb-2 rounded border p-2"
+              placeholder="Comma-separated scene IDs"
+              value={callSceneIds}
+              onChange={(e) => setCallSceneIds(e.target.value)}
+            />
+            <div className="flex gap-2">
+              <button
+                type="button"
+                className="rounded bg-green-600 px-3 py-1 text-white hover:bg-green-700"
+                onClick={runCallSheetPdf}
+              >
+                PDF
+              </button>
+            </div>
+            <pre className="mt-2 h-48 overflow-auto whitespace-pre-wrap break-words rounded bg-gray-100 p-2 text-sm">
+              {callSheetResult}
+            </pre>
+          </section>
       </div>
       <section className="flex flex-col rounded border bg-white p-4 shadow">
         <div className="mb-2 flex items-center justify-between">

--- a/components/ScriptDisplay.tsx
+++ b/components/ScriptDisplay.tsx
@@ -25,25 +25,9 @@ const COLORS = [
   "bg-orange-200",
 ];
 
-function sendScenesToActor(character: string) {
-  fetch("/mcp", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json, text/event-stream",
-    },
-    body: JSON.stringify({
-      jsonrpc: "2.0",
-      id: Date.now(),
-      method: "tools/call",
-      params: { name: "send_actor_scenes_doc", arguments: { character } },
-    }),
-  });
-}
-
-export default function ScriptDisplay({
-  scenes,
-  characters,
+  export default function ScriptDisplay({
+    scenes,
+    characters,
   onAssignActor,
   onUpdateScene,
   filmingStart,
@@ -765,21 +749,13 @@ function SceneInfoPanel({
                 {c.actorName || c.actorEmail ? (
                   <div className="text-xs text-gray-600">
                     {c.actorName && <span>{c.actorName}</span>}
-                    {c.actorName && c.actorEmail && <span> · </span>}
-                    {c.actorEmail && <span>{c.actorEmail}</span>}
-                    {c.actorEmail && (
-                      <button
-                        onClick={() => sendScenesToActor(c.name)}
-                        className="ml-2 underline text-blue-600"
-                      >
-                        Send scenes
-                      </button>
-                    )}
-                  </div>
-                ) : onAssignActor ? (
-                  <button
-                    onClick={() => {
-                      const actorName = prompt(`Actor name for ${c.name}`) || "";
+                      {c.actorName && c.actorEmail && <span> · </span>}
+                      {c.actorEmail && <span>{c.actorEmail}</span>}
+                    </div>
+                  ) : onAssignActor ? (
+                    <button
+                      onClick={() => {
+                        const actorName = prompt(`Actor name for ${c.name}`) || "";
                       const actorEmail = prompt(`Actor email for ${c.name}`) || "";
                       onAssignActor(c.name, actorName, actorEmail);
                     }}

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,11 +3,7 @@ import { z } from "zod";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { parseScript } from "../utils/parseScript";
 import type { Scene as ParsedScene, ScenePart } from "../utils/parseScript";
-import {
-  createGoogleDoc,
-  createGoogleSheet,
-  createPdfCallSheet,
-} from "../utils/google";
+import { createPdfCallSheet } from "../utils/google";
 import PDFDocument from "pdfkit";
 import { marked } from "marked";
 
@@ -856,67 +852,6 @@ export const getServer = (): McpServer => {
     },
   );
 
-  server.tool(
-    "create_call_sheet_doc",
-    "Create Google Docs call sheet for scenes",
-    { sceneIds: z.array(z.string()) },
-    async ({ sceneIds }): Promise<CallToolResult> => {
-      const scenes = sceneStore.filter((s) => sceneIds.includes(s.id));
-      const emails = collectActorEmails(scenes);
-      const content = scenes.map((s) => formatCallSheet(s)).join("\n\n");
-      const url = await createGoogleDoc("Call Sheet", content, emails);
-      return { content: [{ type: "text", text: url }] };
-    },
-  );
-
-  server.tool(
-    "send_actor_scenes_doc",
-    "Create Google Doc of an actor's scenes and share",
-    { character: z.string() },
-    async ({ character }): Promise<CallToolResult> => {
-      const norm = normalizeName(character);
-      const scenes = sceneStore.filter((s) =>
-        s.characters.some((c) => normalizeName(c) === norm),
-      );
-      const actor = findCharacter(character);
-      if (!actor?.actorEmail) {
-        throw new Error("Actor email not found");
-      }
-      const content = scenes.map((s) => formatScene(s)).join("\n\n");
-      const url = await createGoogleDoc(`${character} Scenes`, content, [
-        actor.actorEmail,
-      ]);
-      return { content: [{ type: "text", text: url }] };
-    },
-  );
-
-  server.tool(
-    "create_call_sheet_sheet",
-    "Create Google Sheets call sheet for scenes",
-    { sceneIds: z.array(z.string()) },
-    async ({ sceneIds }): Promise<CallToolResult> => {
-      const scenes = sceneStore.filter((s) => sceneIds.includes(s.id));
-      const emails = collectActorEmails(scenes);
-      const rows: string[][] = [[
-        "Scene",
-        "Setting",
-        "Location",
-        "Time",
-        "Cast",
-      ]];
-      for (const sc of scenes) {
-        rows.push([
-          sc.id,
-          sc.setting,
-          sc.location,
-          sc.time,
-          sc.characters.join(", "),
-        ]);
-      }
-      const url = await createGoogleSheet("Call Sheet", rows, emails);
-      return { content: [{ type: "text", text: url }] };
-    },
-  );
 
   server.tool(
     "create_call_sheet_pdf",


### PR DESCRIPTION
## Summary
- Remove unfinished Google Docs and Sheets MCP tools from server and UI
- Trim debug and script displays to match the updated toolset
- Rewrite README with current features and clearer setup notes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Module not found: Can't resolve 'pdfkit', 'marked', 'googleapis')*

------
https://chatgpt.com/codex/tasks/task_e_68c685b270848320920428360e15327c